### PR TITLE
Fix unintended wrong assignment of address

### DIFF
--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -277,7 +277,7 @@ class Monitor extends EventEmitter {
 
     const options = {
       website: this.website,
-      address: this.website,
+      address: this.address,
       httpOptions: this.httpOptions
     };
 


### PR DESCRIPTION
## 
Here is an error handling 
file: monitor.js 
line: 280
```
  const options = {
      website: this.website,
      address: this.website,
      httpOptions: this.httpOptions
    };
```

assign address to this.website
makes the app crash due to null value and error isn't handled
 
