### PR TITLE
Fix updateRetries func

### DIFF
--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -423,18 +423,25 @@ class Monitor extends EventEmitter {
     this.updateRetries();
   }
 
+  up() {
+    this.isUp = true;
+    this.updateRetries();
+  }
+
   updateRetries(){
+    if(this.isUp){
+      this.retries = 0;
+      this.shouldAlertDown = false;
+      return;
+    }
+
     if(this.retries === this.threshold - 1)
     {
       this.shouldAlertDown = true;
     } else {
-      this.retries += 1;
       this.shouldAlertDown = false;
+      this.retries += 1;
     }
-  }
-
-  up() {
-    this.isUp = true;
   }
 
 

--- a/lib/monitor.js
+++ b/lib/monitor.js
@@ -426,7 +426,6 @@ class Monitor extends EventEmitter {
   updateRetries(){
     if(this.retries === this.threshold - 1)
     {
-      this.retries = 0;
       this.shouldAlertDown = true;
     } else {
       this.retries += 1;


### PR DESCRIPTION
In threshold feature called in down() and shouldAlertDown becomes true even if state didn't change.
If it's still down each N times it becomes TRUE.

The fix to toggle it on state change only